### PR TITLE
Fix compiler issues in the Swift example project

### DIFF
--- a/Example/Swift/FZAccordionTableViewExample/ViewController.swift
+++ b/Example/Swift/FZAccordionTableViewExample/ViewController.swift
@@ -71,19 +71,19 @@ extension ViewController : UITableViewDelegate, UITableViewDataSource {
 
 extension ViewController : FZAccordionTableViewDelegate {
 
-    func tableView(tableView: FZAccordionTableView, willOpenSection section: Int, withHeader header: UITableViewHeaderFooterView) {
+    func tableView(tableView: FZAccordionTableView, willOpenSection section: Int, withHeader header: UITableViewHeaderFooterView?) {
         
     }
     
-    func tableView(tableView: FZAccordionTableView, didOpenSection section: Int, withHeader header: UITableViewHeaderFooterView) {
+    func tableView(tableView: FZAccordionTableView, didOpenSection section: Int, withHeader header: UITableViewHeaderFooterView?) {
         
     }
     
-    func tableView(tableView: FZAccordionTableView, willCloseSection section: Int, withHeader header: UITableViewHeaderFooterView) {
+    func tableView(tableView: FZAccordionTableView, willCloseSection section: Int, withHeader header: UITableViewHeaderFooterView?) {
         
     }
     
-    func tableView(tableView: FZAccordionTableView, didCloseSection section: Int, withHeader header: UITableViewHeaderFooterView) {
+    func tableView(tableView: FZAccordionTableView, didCloseSection section: Int, withHeader header: UITableViewHeaderFooterView?) {
         
     }
     


### PR DESCRIPTION
Looks like the `FZAccordionTableViewDelegate` was switched to use nullable headers but the Swift example project wasn't updated to consume those changes.
