### PR TITLE
Adds section number to header views for more reliable number detection

### DIFF
--- a/FZAccordionTableView/FZAccordionTableView.h
+++ b/FZAccordionTableView/FZAccordionTableView.h
@@ -30,6 +30,13 @@
 
 @interface FZAccordionTableViewHeaderView : UITableViewHeaderFooterView
 
+/*!
+ @desc Contains the section number for easier getting it.
+
+ The default value is NSNotFound.
+ */
+@property (nonatomic) NSInteger sectionNumber;
+
 @end
 
 @interface FZAccordionTableView : UITableView

--- a/FZAccordionTableView/FZAccordionTableView.m
+++ b/FZAccordionTableView/FZAccordionTableView.m
@@ -62,6 +62,7 @@
 }
 
 - (void)singleInit {
+    _sectionNumber = NSNotFound;
     [self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(touchedHeaderView:)]];
 }
 
@@ -257,8 +258,11 @@
 
 - (void)tappedHeaderView:(FZAccordionTableViewHeaderView *)sectionHeaderView {
     NSParameterAssert(sectionHeaderView);
-    
-    NSInteger section = [self sectionForHeaderView:sectionHeaderView];
+
+    NSInteger section = sectionHeaderView.sectionNumber;
+    if (section == NSNotFound) {
+        section = [self sectionForHeaderView:sectionHeaderView];
+    }
     [self toggleSection:section withHeaderView:sectionHeaderView];
 }
 
@@ -496,6 +500,7 @@
         if ([headerView isKindOfClass:[FZAccordionTableViewHeaderView class]]) {
             headerView.delegate = self.accordionTableView;
         }
+        headerView.sectionNumber = section;
     }
     
     return headerView;


### PR DESCRIPTION
Hi! There're some situations when the `FZAccordionTableViewHeaderView` view has slightly different coordinates than the view from the `headerViewForSection:` method. It only appears when the header view has a "dynamic" height, returned from the corresponding method of the table view delegate. And it appears quite rarely, I haven't come up with a definitive way to reproduce it.

It looks like a good idea to save the section number right in the section views. It's quite reliable.